### PR TITLE
Improve dev setup: Run ansible in vagrant vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .vagrant/
 /tests/tmp/
+ubuntu-xenial-16.04-cloudimg-console.log

--- a/Readme.md
+++ b/Readme.md
@@ -8,30 +8,19 @@ We use ansible to setup our main server which runs:
 ## Development
 
 To test and run this ansible playbook locally you need to install:
-- Vagrant >= 1.8
-- Ansible >= 2.5 installed or Docker
+- Vagrant >= 2.0
+- VirtualBox >= 6.0
 
-**Ansible installed:** 
-```
-ansible-galaxy install -r requirements.yml
-export ENVIRONMENT=dev
-ansible-playbook site.yml -i ./hosts/hosts_vagrant --key-file "./docker-ansible-runner/vagrant.key"
-```
-
-**Else use provided docker image:**
-If you don't have Ansible installed you can use the dockerized version. Build docker image first:
-```
-docker build -t docker-ansible-runner docker-ansible-runner
-```
-
-Then execute: `./infra.sh runAnsible vagrant`
+Start and setup the dev VM with: `vagrant up`
+To deploy the demo server execute: `./infra.sh runAnsible vagrant`
+And browse to: `http://localhost:8080`
 
 ## CLI Usage
 
 The CLI tool `infra.sh` is used to manage demos and run ansible:
  - `./infra.sh deployDemo <branchName> <buildNumber> <triggeredBy> <pullrequestURL> <pullrequestNumber>`
  - `./infra.sh undeployDemo <branchName>`
- - `./infra.sh runAnsible <vagrant|aws> <pathToAlternativeSSHKey>`
+ - `./infra.sh runAnsible <vagrant|aws|demoserver> <pathToAlternativeSSHKey>`
  - `./infra.sh updateOverview`
  - `./infra.sh cleanupDemos`
  
@@ -108,3 +97,16 @@ To get the most out of the box without running into Java OutOfMemoryExceptions w
 - System: 1GB
 - Elasticsearch: 0.8GB  (500MB Java + docker overhead)  see `roles/docker/tasks/main.yml`
 - Tomcat: 6GB (1GB per demo is a good measure)  see `roles/tomcat/files/setenv.sh`
+
+
+### Dockerized ansible
+
+If you would like to deploy a server on AWS (`see hosts/hosts_aws`) or the demo server directly (`hosts/hosts_demoserver_ovh`),
+you can use the dockerized ansible.
+Build docker image first:
+```
+docker build -t docker-ansible-runner docker-ansible-runner
+```
+
+Then execute: `./infra.sh runAnsible aws`
+You can also provide an alternative ssh key like this: `./infra.sh runAnsible aws ./.ssh/my_aws_ssh_key`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,4 @@
-Vagrant.require_version ">= 1.8.0"
-# For vagrant < 2.x fix place where base boxes are fetched https://github.com/hashicorp/vagrant/issues/9442
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+Vagrant.require_version ">= 2.0.0"
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64" # aka Ubuntu 16.04 LTS
   config.vm.network :private_network, ip: "192.168.111.222"
@@ -9,12 +7,10 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 9200, host: 9200
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 4024
+    v.memory = 6024
     v.cpus = 2
   end
 
-  # Don't replace the default insecure key or our dockerized ansible won't be able to login
-  config.ssh.insert_key = false
   config.vm.define "mainserver"
-  config.vm.provision "shell", inline: "apt-get -y update; apt-get -y install jq bats"
+  config.vm.provision "shell", path: "vagrantSetup.sh"
 end

--- a/hosts/hosts_aws
+++ b/hosts/hosts_aws
@@ -1,6 +1,3 @@
-[all:vars]
-env=vagrant
-
 [mainserver]
 54.77.179.63
 

--- a/hosts/hosts_vagrant
+++ b/hosts/hosts_vagrant
@@ -2,9 +2,9 @@
 env=vagrant
 
 [mainserver]
-127.0.0.1:2222
+localhost
 
 [all:vars]
-ansible_connection=ssh
+ansible_connection=local
 ansible_user=vagrant
 ansible_python_interpreter=/usr/bin/python3

--- a/hosts/hosts_vagrant_docker
+++ b/hosts/hosts_vagrant_docker
@@ -1,9 +1,0 @@
-[all:vars]
-env=vagrant
-[mainserver]
-host.docker.internal:2222
-
-[all:vars]
-ansible_connection=ssh
-ansible_user=vagrant
-ansible_python_interpreter=/usr/bin/python3

--- a/vagrantSetup.sh
+++ b/vagrantSetup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+echo
+echo
+echo "INSTALLING: jq, bats & ansible ... (may take a minute)"
+
+# Install jq, bats and ansible in vagrant VM
+apt-get -y update > /dev/null
+apt-get install -y jq bats libffi-dev libssl-dev python-pip > /dev/null
+
+pip install 'ansible==2.5.0' > /dev/null
+
+echo
+echo "Vagrant VM ready. To deploy demoserver with ansible execute:"
+echo
+echo "  ./infra.sh runAnsible vagrant"
+echo


### PR DESCRIPTION
The combination of docker and vagrant on windows was problematic. Execute ansible directly in vagrant during development to facilitate dev setup.

@eggerschwiler I tried to make some changes so dev becomes easier on windows. Could you please try with this setup if it works for you?
Please make sure to install Vagrant >= 2.0 and probably a recent Virtualbox as well.