### PR TITLE
Prevent caching of demos.json

### DIFF
--- a/overviewpage/index.html
+++ b/overviewpage/index.html
@@ -40,7 +40,7 @@
         const d = document;
         window.onload = function () {
             const getDemoRequest = new Request('demos.json');
-            fetch(getDemoRequest)
+            fetch(getDemoRequest, {cache: "no-store"})
                 .then(response => response.json())
                 .then(updateDemos);
         };


### PR DESCRIPTION
Demos.json is cached by default, which leads to an outdated overviewpage. By setting no-store we prevent that this resource is cached locally and we always get an up to date list.