### PR TITLE
#877 Rest Service providing information if Imports or Comparisons are currently being processed

### DIFF
--- a/roles/deployBranch/tasks/main.yml
+++ b/roles/deployBranch/tasks/main.yml
@@ -148,3 +148,23 @@
     dest: "{{ config.tomcatFolder }}/webapps/scenarioo-{{ branch }}.war"
     sha256sum: "{{ branchConfig.warArtifactSha256 }}"     # Will only download if checksum changed
   no_log: true  # Don't show CIRCLE_TOKEN in logs
+
+- name: "{{ branch }} - Wait for deployment"
+  uri:
+    url: "http://{{ config.scenariooHost }}/scenarioo-{{ branch }}"
+    status_code: 200
+  register: result
+  until: result.status == 200
+  delay: 3
+  retries: 60
+  when: lookup('env', 'ENVIRONMENT') != 'dev'   # Because would fail when using vagrant
+
+- name: "{{ branch }} - Wait for Imports to finish"
+  uri:
+    url: "http://{{ config.scenariooHost }}/scenarioo-{{ branch }}/rest/builds/importsAndComparisonCalculationsFinished"
+    return_content: yes
+  register: this
+  until: "'true' in this.content"
+  delay: 3
+  retries: 60
+  when: lookup('env', 'ENVIRONMENT') != 'dev'   # Because would fail when using vagrant

--- a/roles/reimportBuilds/tasks/main.yml
+++ b/roles/reimportBuilds/tasks/main.yml
@@ -17,3 +17,13 @@
     status_code: 200,204
   when: lookup('env', 'ENVIRONMENT') != 'dev'   # Because would fail when using vagrant
 
+- name: "{{ branch }} - Wait for Imports to finish"
+  uri:
+    url: "http://{{ config.scenariooHost }}/scenarioo-{{ branch }}/rest/builds/importsAndComparisonCalculationsFinished"
+    return_content: yes
+  register: this
+  until: "'true' in this.content"
+  delay: 3
+  retries: 60
+  when: lookup('env', 'ENVIRONMENT') != 'dev'   # Because would fail when using vagrant
+

--- a/roles/reimportBuilds/tasks/main.yml
+++ b/roles/reimportBuilds/tasks/main.yml
@@ -15,6 +15,10 @@
   uri:
     url: "http://{{ config.scenariooHost }}/scenarioo-{{ branch }}/rest/builds/updateAndImport"
     status_code: 200,204
+  register: result
+  until: result.status == 200 or result.status == 204
+  delay: 3
+  retries: 60
   when: lookup('env', 'ENVIRONMENT') != 'dev'   # Because would fail when using vagrant
 
 - name: "{{ branch }} - Wait for Imports to finish"

--- a/site.yml
+++ b/site.yml
@@ -60,14 +60,6 @@
           loop_var: branch
 
     #
-    # Stop Tomcat to prevent "Illegal access: this web application instance has been stopped already" in Tomcat Logs.
-    #
-    - name: Stop Tomcat
-      service:
-        name=tomcat8
-        state=stopped
-
-    #
     # ENSURE ACTIVE BRANCHES ARE DEPLOYED
     #
     - name: Deploy active branches
@@ -78,12 +70,12 @@
           loop_var: branch
 
     #
-    # Start Tomcat to prevent "Illegal access: this web application instance has been stopped already" in Tomcat Logs.
+    # Restart Tomcat to prevent "Illegal access: this web application instance has been stopped already" in Tomcat Logs.
     #
     - name: Start Tomcat
       service:
         name=tomcat8
-        state=started
+        state=restarted
 
     #
     # Reimport Builds


### PR DESCRIPTION
Supply rest endpoint which returns true if all imports were imported and all comparisons were calculated.

Deploy war into a running Tomcat, but wait until all wars are deployed and all imports are finished before restarting the Tomcat. When triggering updateAndImport also wait until all imports are finished.

see corresponding pull request in scenarioo/scenarioo: https://github.com/scenarioo/scenarioo/pull/890

Preventing multiple builds to execute the ansible playbook on scenarioo-infrastructure, which was another source of potentially failing builds, has already been committed to scenarioo-infrastructure/master.